### PR TITLE
Supported black list

### DIFF
--- a/Example/WXNavigationBarDemo/AppDelegate.swift
+++ b/Example/WXNavigationBarDemo/AppDelegate.swift
@@ -19,6 +19,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         WXNavigationBar.setup()
         
         WXNavigationBar.NavBar.backgroundColor = .secondarySystemBackground
+        WXNavigationBar.NavBar.blacklist = [PaymentViewController(), PresentViewController()]
         
         let rootViewController = RootViewController()
         window = UIWindow(frame: UIScreen.main.bounds)

--- a/Example/WXNavigationBarDemo/AppDelegate.swift
+++ b/Example/WXNavigationBarDemo/AppDelegate.swift
@@ -19,7 +19,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         WXNavigationBar.setup()
         
         WXNavigationBar.NavBar.backgroundColor = .secondarySystemBackground
-        WXNavigationBar.NavBar.blacklist = [PaymentViewController(), PresentViewController()]
+        WXNavigationBar.NavBar.blacklist = ["PresentViewController"]
         
         let rootViewController = RootViewController()
         window = UIWindow(frame: UIScreen.main.bounds)

--- a/Sources/UIViewController+WXNavigationBar.swift
+++ b/Sources/UIViewController+WXNavigationBar.swift
@@ -238,7 +238,8 @@ extension UIViewController {
             if let parent = parent, !(parent is UINavigationController)  && wx_automaticallyHideWXNavBarInChildViewController {
                 wx_navigationBar.isHidden = true
             }
-            if WXNavigationBar.NavBar.blacklist.filter({ self.isKind(of: $0.classForCoder) }).first != nil {
+            print(String(describing: self.classForCoder))
+            if WXNavigationBar.NavBar.blacklist.filter({ String(describing: self.classForCoder) == $0 }).first != nil {
                 wx_navigationBar.isHidden = true
             }
         }

--- a/Sources/UIViewController+WXNavigationBar.swift
+++ b/Sources/UIViewController+WXNavigationBar.swift
@@ -238,6 +238,9 @@ extension UIViewController {
             if let parent = parent, !(parent is UINavigationController)  && wx_automaticallyHideWXNavBarInChildViewController {
                 wx_navigationBar.isHidden = true
             }
+            if WXNavigationBar.NavBar.blacklist.filter({ self.isKind(of: $0.classForCoder) }).first != nil {
+                wx_navigationBar.isHidden = true
+            }
         }
         
         wx_viewDidLoad()

--- a/Sources/WXNavigationBar.swift
+++ b/Sources/WXNavigationBar.swift
@@ -34,6 +34,9 @@ public class WXNavigationBar: UIView {
         
         /// A Boolean value indicating whether fullscreen pop gesture is enabled.
         public static var fullscreenPopGestureEnabled = false
+        
+        /// In this black list, fake NavigationBar does not exist.
+        public static var blacklist: [UIViewController] = []
     }
     
     /// Bottom line

--- a/Sources/WXNavigationBar.swift
+++ b/Sources/WXNavigationBar.swift
@@ -35,8 +35,8 @@ public class WXNavigationBar: UIView {
         /// A Boolean value indicating whether fullscreen pop gesture is enabled.
         public static var fullscreenPopGestureEnabled = false
         
-        /// In this black list, fake NavigationBar does not exist.
-        public static var blacklist: [UIViewController] = []
+        /// In this black list, fake NavigationBar does not exist, it should be class names.
+        public static var blacklist: [String] = []
     }
     
     /// Bottom line

--- a/WXNavigationBar.podspec
+++ b/WXNavigationBar.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'WXNavigationBar'
-  s.version      = '2.3.6'
+  s.version      = '2.3.7'
   s.license = 'MIT'
   s.requires_arc = true
   s.source = { :git => 'https://github.com/alexiscn/WXNavigationBar.git', :tag => s.version.to_s }


### PR DESCRIPTION
因为有时候会用到其他仓库的UI组件，有些仓库在操作转场的方法里处理了控制器，但是没有公开该方法，导致无法继承修改，所以有必要加一个黑名单，来屏蔽哪些控制器添加 WXNavigationBar。